### PR TITLE
Specify files to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/mafintosh/stream-shift/issues"
   },
-  "homepage": "https://github.com/mafintosh/stream-shift"
+  "homepage": "https://github.com/mafintosh/stream-shift",
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Currently the tests and `.travis.yml` are being published to npm. Considering that they make this package a tiny bit larger, it would be worthwhile to exclude them.

This PR excludes them using the using the [`files`](https://docs.npmjs.com/files/package.json#files) whitelist in the `package.json`.